### PR TITLE
全体的なスタイル変更

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -41,14 +41,15 @@ export default {
 <template>
   <div>
     <h1>都道府県別の総人口推移グラフ</h1>
-    <div v-if="loading">Loading...</div>
-    <div v-else class="pref-container">
-      <div v-for="prefecture in prefectures" :key="prefecture.prefCode" class="pref-item">
-        <input type="checkbox" :id="'prefecture-' + prefecture.prefCode" v-model="selectedPrefectures"
-          :value="prefecture.prefCode" />
-        <label :for="'prefecture-' + prefecture.prefCode">{{ prefecture.prefName }}</label>
+      <span class="pref">＜都道府県一覧＞</span>
+      <div v-if="loading">Loading...</div>
+      <div v-else class="pref-container">
+        <div v-for="prefecture in prefectures" :key="prefecture.prefCode" class="pref-item">
+          <input type="checkbox" :id="'prefecture-' + prefecture.prefCode" v-model="selectedPrefectures"
+            :value="prefecture.prefCode" />
+          <label :for="'prefecture-' + prefecture.prefCode">{{ prefecture.prefName }}</label>
+        </div>
       </div>
-    </div>
     <PopulationChart :selectedPrefectures="selectedPrefectures" :selectedPrefectureNames="selectedPrefectureNames" />
   </div>
 </template>
@@ -62,16 +63,23 @@ header {
   line-height: 1.5;
 }
 
+.pref{
+  padding-left: 10px;
+  font-size: 20px;
+}
 .pref-container {
   display: flex;
   flex-wrap: wrap;
-  margin-left: 10%;
+  align-items: center;
 }
 
 .pref-item {
-  width: calc(100% / 6);
+  width: calc(100% / 5);
+  padding: 10px 15px 0 0;
   box-sizing: border-box;
   padding-top: 10;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 @media (min-width: 1024px) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -55,7 +55,7 @@ export default {
 </template>
 
 <style scoped>
-h1 {
+h1{
   text-align: center;
 }
 
@@ -64,13 +64,14 @@ header {
 }
 
 .pref{
-  padding-left: 10px;
+  display: block;
+  margin-left: 5%;
   font-size: 20px;
 }
 .pref-container {
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
+  text-align: center;
 }
 
 .pref-item {

--- a/src/components/PopulationChart.vue
+++ b/src/components/PopulationChart.vue
@@ -91,21 +91,40 @@ export default {
                   position: 'bottom',
                   title: {
                     display: true,
-                    text: '年',
+                    text: '年度',
                     font: {
                       size: 14,
                       weight: "bold",
                     },
                   },
                   ticks: {
+                    stepSize: 5,
                     callback: function (value) {
-                      return value.toString();
-                    }
-                  }
+                      return value.toString().replace(/\B(?=(\d{3})+(?!\d))/g, "");
+                    },
+                  },
                 },
                 y: {
                   title: {
                     display: true,
+                    text: '人口',
+                    font: {
+                      size: 14,
+                      weight: "bold",
+                    },
+                  },
+                },
+              },
+              plugins: {
+                tooltip: {
+                  callbacks: {
+                    label: function (context) {
+                      const value = context.parsed.y;
+                      const formattedValue = value.toLocaleString();
+                      const year = context.parsed.x;
+                      const prefecture = context.dataset.label;
+                      return `${year}年 ${prefecture} ${formattedValue}人`;
+                    },
                   },
                 },
               },
@@ -186,9 +205,11 @@ export default {
 
 <template>
   <div>
-    <button @click="fetchPopulationData">表示</button>
+    <div class="button-container">
+      <button @click="fetchPopulationData" class="button">表示</button>
+    </div>
     <div v-if="loading || chartData.labels.length === 0">Loading...</div>
-    <div v-else>
+    <div v-else class="chart">
       <line-chart :data="chartData" :options="chartOptions"></line-chart>
     </div>
     <canvas id="prefChart"></canvas>
@@ -196,4 +217,17 @@ export default {
 </template>
 
 <style scoped>
+.button-container {
+  text-align: center;
+}
+
+.button {
+  margin: 20px auto 0;
+  padding: 10px 20px;
+  font-size: medium;
+}
+
+.chart {
+  margin-top: 20px;
+}
 </style>


### PR DESCRIPTION
### 変更点
- グラフ上の●にカーソルをあわせると、以下の詳細が表示される
・年代
・県名
・その年代の総人口
<img width="786" alt="スクリーンショット 2024-02-06 18 32 15" src="https://github.com/airi-i-1998/prefectures-populations/assets/138418114/e2ceacc5-c84a-40ad-9a3c-28b67d4217c8">

- PC/スマートフォン表示に対応すること(レスポンシブデザイン対応)
→サイズ：iPhone14Pro
<img width="975" alt="スクリーンショット 2024-02-06 18 31 03" src="https://github.com/airi-i-1998/prefectures-populations/assets/138418114/c5eacba4-7b4b-4123-b390-4cc14b70c927">

- 都道府県のチェックリストを真ん中の位置にセット