### PR TITLE
apiKey設定方法変更

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -12,7 +12,7 @@ export default {
     };
   },
   mounted() {
-    const apiKey = your-api-key;
+    const apiKey =  import.meta.env.VITE_APP_RESAS_API_KEY
     // APIリクエスト
     axios.get('https://opendata.resas-portal.go.jp/api/v1/prefectures', {
       headers: {

--- a/src/components/PopulationChart.vue
+++ b/src/components/PopulationChart.vue
@@ -31,7 +31,8 @@ export default {
         this.prefChart.destroy();
         this.prefChart = null;
       }
-      const apiKey = your-api-key;
+      const apiKey =  import.meta.env.VITE_APP_RESAS_API_KEY
+      // const apiKey = "50FXDSxFzOObNVDiZW9EBtkJxMWdYjtlrPsP9DH7";
       this.loading = true;
       // 選択された都道府県ごとにAPIリクエストを実行
       const requests = this.selectedPrefectures.map(prefCode => {
@@ -175,7 +176,7 @@ export default {
     }
   },
   mounted() {
-    const apiKey = your-api-key;
+    const apiKey =  import.meta.env.VITE_APP_RESAS_API_KEY
     // prefecturesの取得が完了してからfetchPopulationDataを呼び出す
     axios.get('https://opendata.resas-portal.go.jp/api/v1/prefectures', {
       headers: {


### PR DESCRIPTION
RESAS(地域経済分析システム) のAPI Keyを発行した後、
直接コード上にAPI keyをおいてしまうとセキュリティー上、問題が発生してしまう。
そのため、以下の流れでAPI KeyがVueページで読み込めるように設定する。
①ルートディレクトリに`.env`を作成
```
VITE_APP_RESAS_API_KEY="your api key"
```
②サーバー再起動
※Vueページ内には、以下のようにコードを書いている。
```
const apiKey =  import.meta.env.VITE_APP_RESAS_API_KEY
```